### PR TITLE
doc(tutorials): adapt provide data section

### DIFF
--- a/docs/tutorials/e2e/boost/consumeData.md
+++ b/docs/tutorials/e2e/boost/consumeData.md
@@ -14,13 +14,13 @@ To see Bob's data offerings, Alice must request access to his catalog. The catal
 So Alice requests Bob's catalog using the following `curl` commands:
 
 ```shell
-curl --location 'http://localhost/alice/management/v2/catalog/request' \
+curl --location 'http://dataconsumer-1-controlplane.tx.test/management/v2/catalog/request' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST1' \
 --data-raw '{
     "@context": {},
     "protocol": "dataspace-protocol-http",
-    "counterPartyAddress": "http://bob-controlplane:8084/api/v1/dsp",
+    "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
     "querySpec": {
         "offset": 0,
         "limit": 100
@@ -34,22 +34,26 @@ Alice finds the Asset with the ID 3 and the description "Product EDC Demo Asset 
 
 ## Negotiate a contract
 
+:::info
+Dont forget to change the `offerId`with the one you received in the previous step in your catalog request.
+:::
+
 But before she can transfer the data, she must negotiate the contract with Bob. To do this, she uses the following `curl` command:
 
 ```shell
-curl --location 'http://localhost/alice/management/v2/contractnegotiations' \
+curl --location 'http://dataconsumer-1-controlplane.tx.test/management/v2/contractnegotiations' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST1' \
 --data-raw '{
  "@context": {
     "odrl": "http://www.w3.org/ns/odrl/2/"
  },
  "@type": "NegotiationInitiateRequestDto",
- "connectorAddress": "http://bob-controlplane:8084/api/v1/dsp",
+ "connectorAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
  "protocol": "dataspace-protocol-http",
- "providerId": "BPNL000000000002",
+ "providerId": "BPNL00000003AYRE",
  "offer": {
-    "offerId": "Mw==:Mw==:ODRkYjJhZjQtZjMxOC00ZjgyLThjMjktODQwZThjYjBjNjVl",
+    "offerId": "Mw==:Mw==:NTYzYWRkYTItNmEzMy00YTNhLWFmOTQtYjVjOWM0ZDMyODA1",
     "assetId": "3",
     "policy": {
         "@type": "odrl:Set",
@@ -62,15 +66,39 @@ curl --location 'http://localhost/alice/management/v2/contractnegotiations' \
 }' | jq
 ```
 
-In the response, Alice gets a UUID. This is the ID of the created contract negotiation. Alice can now use this ID to see the current status of the negotiation and - if the negotiation was successful - the ID of the created contract agreement.
+The response should look like this:
+
+```json
+{
+  "@type": "edc:IdResponse",
+  "@id": "65356596-dd7c-4ad4-8fc6-8512be6f0ec2",
+  "edc:createdAt": 1715669329095,
+  "@context": {
+    "dct": "https://purl.org/dc/terms/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dcat": "https://www.w3.org/ns/dcat/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/v0.8/"
+  }
+}
+```
+
+In the response, Alice gets a UUID (attribute is `@id`). This is the ID of the created contract negotiation. Alice can now use this ID to see the current status of the negotiation and - if the negotiation was successful - the ID of the created contract agreement.
 
 :::tip
-Make sure to replace `<ID>` in the URL with the UUID you just received.
+Make sure to replace `<ID>` in the URL with the UUID you just received. in the current case the UUID is `65356596-dd7c-4ad4-8fc6-8512be6f0ec2`. So the curl command should look like this:
+
+```shell
+curl --location 'http://dataconsumer-1-controlplane.tx.test/management/v2/contractnegotiations/65356596-dd7c-4ad4-8fc6-8512be6f0ec2' \
+--header 'X-Api-Key: TEST1' | jq
+```
+
 :::
 
 ```shell
-curl --location 'http://localhost/alice/management/v2/contractnegotiations/<ID>' \
---header 'X-Api-Key: password' | jq
+curl --location 'http://dataconsumer-1-controlplane.tx.test/management/v2/contractnegotiations/<ID>' \
+--header 'X-Api-Key: TEST1' | jq
 ```
 
 - If the negotiation was **successful**, Alice will see an ouput as shown below.
@@ -79,15 +107,15 @@ curl --location 'http://localhost/alice/management/v2/contractnegotiations/<ID>'
 ```json
 {
   "@type": "edc:ContractNegotiation",
-  "@id": "4e74a632-94bc-4bfb-acf5-230f7d18b080",
+  "@id": "65356596-dd7c-4ad4-8fc6-8512be6f0ec2",
   "edc:type": "CONSUMER",
   "edc:protocol": "dataspace-protocol-http",
   "edc:state": "FINALIZED",
-  "edc:counterPartyId": "BPNL000000000002",
-  "edc:counterPartyAddress": "http://bob-controlplane:8084/api/v1/dsp",
+  "edc:counterPartyId": "BPNL00000003AYRE",
+  "edc:counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
   "edc:callbackAddresses": [],
-  "edc:createdAt": 1702989093837,
-  "edc:contractAgreementId": "Mw==:Mw==:NmY5MDA4OGEtOWY1ZC00YmYyLWFiZjMtMjRiNzY0YzEyOTk4",
+  "edc:createdAt": 1715669329095,
+  "edc:contractAgreementId": "Mw==:Mw==:N2RhZGI3OGMtYzUxNC00OTkzLWI3MzktNDE3YmJhMDNkMDU4",
   "@context": {
     "dct": "https://purl.org/dc/terms/",
     "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
@@ -107,7 +135,7 @@ Alice wants to send the data to her backend application ("<http://backend:8080>"
 
 :::warning
 
-For testing purposes, you should replace `backend:8080` with your own test API or use [webhook.site](https://webhook.site/) as your backend system.
+For testing purposes, you should replace `<backend>` with your own test API or use [webhook.site](https://webhook.site/) as your backend system.
 If you do not change this, you will not be able to view the received token, which is required for requesting the data!
 If you are using webhook.site, please make sure that you use "Your unique URL" and that you do not transfer any sensitive information to webhook.
 
@@ -115,22 +143,22 @@ Replace `<contractAgreementId>` with the contract agreement ID you received in t
 :::
 
 ```shell
-curl --location 'http://localhost/alice/management/v2/transferprocesses' \
+curl --location 'http://dataconsumer-1-controlplane.tx.test/management/v2/transferprocesses' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST1' \
 --data-raw '{
     "@context": {
         "odrl": "http://www.w3.org/ns/odrl/2/"
     },
     "assetId": "3",
-    "connectorAddress": "http://bob-controlplane:8084/api/v1/dsp",
-    "connectorId": "BPNL000000000002",
+    "connectorAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
+    "connectorId": "BPNL00000003AYRE",
     "contractId": "<contractAgreementId>",
     "dataDestination": {
         "type": "HttpProxy"
     },
     "privateProperties": {
-        "receiverHttpEndpoint": "http://backend:8080"
+        "receiverHttpEndpoint": "<backend:8080>"
     },
     "protocol": "dataspace-protocol-http",
     "transferType": {
@@ -140,17 +168,41 @@ curl --location 'http://localhost/alice/management/v2/transferprocesses' \
 }' | jq
 ```
 
+The response in this case looks like this:
+
+```json
+{
+  "@type": "edc:IdResponse",
+  "@id": "9d6a0507-25f5-4a81-8885-a47bc3809451",
+  "edc:createdAt": 1715669899367,
+  "@context": {
+    "dct": "https://purl.org/dc/terms/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dcat": "https://www.w3.org/ns/dcat/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/v0.8/"
+  }
+}
+```
+
 Just to make sure everything worked, Alice uses another `curl` command to check if the transfer was successful.
 
 In the response, Alice gets a UUID. This is the ID of the created transfer. Alice can now use this ID to see the current status of the transfer.
 
 :::tip
-Make sure to replace `<ID>` in the URL with the UUID you just received.
+Make sure to replace `<ID>` in the URL with the UUID you just received. In our case, the UUID is `9d6a0507-25f5-4a81-8885-a47bc3809451`. So the curl command should look like this:
+
+```shell
+curl --location 'http://dataconsumer-1-controlplane.tx.test/management/v2/transferprocesses/9d6a0507-25f5-4a81-8885-a47bc3809451' \
+--header 'X-Api-Key: TEST1' | jq
+```
+
 :::
 
 ```shell
-curl --location 'http://localhost/alice/management/v2/transferprocesses/<ID>' \
---header 'X-Api-Key: password' | jq
+curl --location 'http://dataconsumer-1-controlplane.tx.test/management/v2/transferprocesses/<ID>' \
+--header 'X-Api-Key: TEST1' | jq
 ```
 
 - If the transfer was **successful**, Alice will see an ouput as shown below.
@@ -158,20 +210,20 @@ curl --location 'http://localhost/alice/management/v2/transferprocesses/<ID>' \
 
 ```json
 {
-  "@id": "6d6bca4e-4da5-4ed3-9fe5-2b98623d9a59",
+  "@id": "9d6a0507-25f5-4a81-8885-a47bc3809451",
   "@type": "edc:TransferProcess",
-  "edc:correlationId": "6d6bca4e-4da5-4ed3-9fe5-2b98623d9a59",
+  "edc:correlationId": "9d6a0507-25f5-4a81-8885-a47bc3809451",
   "edc:state": "STARTED",
-  "edc:stateTimestamp": 1702990026966,
+  "edc:stateTimestamp": 1715669901450,
   "edc:type": "CONSUMER",
   "edc:assetId": "3",
-  "edc:contractId": "Mw==:Mw==:NmY5MDA4OGEtOWY1ZC00YmYyLWFiZjMtMjRiNzY0YzEyOTk4",
+  "edc:contractId": "Mw==:Mw==:N2RhZGI3OGMtYzUxNC00OTkzLWI3MzktNDE3YmJhMDNkMDU4",
   "edc:callbackAddresses": [],
   "edc:dataDestination": {
     "@type": "edc:DataAddress",
     "edc:type": "HttpProxy"
   },
-  "edc:connectorId": "BPNL000000000002",
+  "edc:connectorId": "BPNL00000003AYRE",
   "@context": {
     "dct": "https://purl.org/dc/terms/",
     "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
@@ -201,10 +253,10 @@ In her backend (as already mentioned [webhook.site](https://webhook.site/)) you 
 
 ```json
 {
-  "id": "841e3cd7-add0-47fd-adef-ea8074ec50af",
-  "endpoint": "http://bob-tractusx-connector-dataplane:8081/api/public",
+  "id": "9d6a0507-25f5-4a81-8885-a47bc3809451",
+  "endpoint": "http://dataprovider-dataplane.tx.test/api/public",
   "authKey": "Authorization",
-  "authCode": "eyJhbGciOiJFUzI1NiJ9.eyJleHAiOjE3MTE5MTIzMDgsImRhZCI6IktaamRBV3ZSV0xpS3V5akNwSjRIdEgwT2lqOEdQRno2SVdXcWxMMEFFZUloS25wOU5mZll2R1Q0M0N4dURZVHhUK3lRaXhrcWU1dVN1Sk5JR09GTi9kRlQ4R29WNGFHZ3FpdzhXMXBLT2ZLMUdtM1NkeFRIeWR0QTlnTnZoZFJ6T05RclpxbUlwNGxwZVBRaS9CSGVNTEYycEVsRVUvcExzU3dTbDh3eUplY3lSM2thTnJiUUw0a3RnajNMeDBjWUp3ZHZlS2h3OUdMYjF1UnBDa3I0RE5sOG4zQlprZ1ZEK1RYUGtIaGhXVWNpck1Tc3FBZHdyN3kvRFE0Nlp5S09GbldtTmVkdEVaempLWmRRRUlWMkcyV2d2cXFya25WdkNvTzhPZWpXZU1MaXUvdnl2cWdTZmp2dkk4cHhIOTRzYS90LzdGazB2YlRuMmpNMjQ3TFZQUlcvMk9wRElZWTA0dVRYY2p2T0h2L1UvcU5heURnR09uaitBbjcyZnNiOUZhWVZLMzQ4TzRYKzFDMkRvUjBwem9nQmJyRGMzSzRNQzBSdjcvVT0iLCJjaWQiOiJNdz09Ok13PT06WTJJelpHTXdaR1l0WVRNeVlpMDBZamM1TFdFNFkyTXROVE5rWWpVeU5tWXpNR0ZpIn0._2G-2eVzIQrTh-JW0Dx_P9nG2bAElPFllYtpN_s7MXk6R-F5jdMyCblMD6uJDw-H7J0SMiW5IAYExcZkMn-65w",
+  "authCode": "eyJhbGciOiJSUzI1NiJ9.eyJleHAiOjE3MTU2NzA1MDEsImRhZCI6IjFFQ29ReDRBTy9acmJ6dXEwUlpSY0tYd1hQeW81UmdPZndyRWtIWnpZSStQVGhIUmFuelczeGpXcU5vTzFJa3ZOWUV6SGpEWU5iVEJ5VDgzbzdtVlVsUWZhYUpKSm5CMVJGbFQ1SXM0NHpZQ0RJYWZKNHhmQzZTOFNKaWxjV0x1WURoc24xRjdha2xSZllnemRIMjR3WnJycS9JU0pPZjFzVHNQSHNtcE9PaWZ2S2ZyaElFemtJSEs3OFZUTFBMd0krWmNEK3VZc1FCQkt5NlEvZFBCSkZodWsyMXFiOVU1V3dZWWpPYkZSQjdzUmpZYkNsSlpyaTZzVWFXQU1WOXVsQ2JGS2NPM2xxMERPaWRuQjNqSXJ4blh4Y3JjVHl3MEkzV3JjN2k2ZG1nejlXMTFvYTR5VUpJWU92R1lkdWNXdk1pemk3b01mck5SdXE0SVJ1djR6ai9Cemcxb2NZalB5Y0RvK2I2M0RheWpyWmVNS1c4OGNRUnlvUDdpbExsMVNVVmFlRUxZQ3lieitCYUxpd2x1d0lpcWxFckJrTDNlOXptNGpJYz0iLCJjaWQiOiJNdz09Ok13PT06TjJSaFpHSTNPR010WXpVeE5DMDBPVGt6TFdJM016a3ROREUzWW1KaE1ETmtNRFU0In0.AOt6rXbcK44RD7XNCMN16zjvurzdkMNCki3HkvZ_VJ43eDkCDDbquDSvW0SmEnp9cqhjMbUqnO-iGJheI4TbkIc9dxFouJGtHvKFAjOG7LFSErwvH0yNXus1TPN41BCp_jP1tpH63s3PuRqgdzzn1axkJ57aGo9ibqnKRm7ZhM8pgkReWQpHwlFz3QuOMFWHNmPm_HMePPsUxZM7OpARwgShGMqATHEJmoIff2S1yLLeN0k97JT4BzL7xwM9VB-Yssq1rWxBp3GITcBta5R1EVjzaEZseYn_wxFFmVlXQtu_lkvbgihEsvCgtXI_c-EGZl_gTVe9DMfq4cM2XXfE8A",
   "properties": {}
 }
 ```
@@ -222,7 +274,19 @@ In this example, we can not use the endpoint URL as is, because we are working w
 In this example, this results in the following request:
 
 ```shell
-curl -X GET -H 'Authorization: eyJhbGciOiJFUzI1NiJ9.eyJleHAiOjE3MTE5MTIzMDgsImRhZCI6IktaamRBV3ZSV0xpS3V5akNwSjRIdEgwT2lqOEdQRno2SVdXcWxMMEFFZUloS25wOU5mZll2R1Q0M0N4dURZVHhUK3lRaXhrcWU1dVN1Sk5JR09GTi9kRlQ4R29WNGFHZ3FpdzhXMXBLT2ZLMUdtM1NkeFRIeWR0QTlnTnZoZFJ6T05RclpxbUlwNGxwZVBRaS9CSGVNTEYycEVsRVUvcExzU3dTbDh3eUplY3lSM2thTnJiUUw0a3RnajNMeDBjWUp3ZHZlS2h3OUdMYjF1UnBDa3I0RE5sOG4zQlprZ1ZEK1RYUGtIaGhXVWNpck1Tc3FBZHdyN3kvRFE0Nlp5S09GbldtTmVkdEVaempLWmRRRUlWMkcyV2d2cXFya25WdkNvTzhPZWpXZU1MaXUvdnl2cWdTZmp2dkk4cHhIOTRzYS90LzdGazB2YlRuMmpNMjQ3TFZQUlcvMk9wRElZWTA0dVRYY2p2T0h2L1UvcU5heURnR09uaitBbjcyZnNiOUZhWVZLMzQ4TzRYKzFDMkRvUjBwem9nQmJyRGMzSzRNQzBSdjcvVT0iLCJjaWQiOiJNdz09Ok13PT06WTJJelpHTXdaR1l0WVRNeVlpMDBZamM1TFdFNFkyTXROVE5rWWpVeU5tWXpNR0ZpIn0._2G-2eVzIQrTh-JW0Dx_P9nG2bAElPFllYtpN_s7MXk6R-F5jdMyCblMD6uJDw-H7J0SMiW5IAYExcZkMn-65w' http://localhost/bob/api/public
+curl -X GET -H 'Authorization: eyJhbGciOiJSUzI1NiJ9.eyJleHAiOjE3MTU2NzA1MDEsImRhZCI6IjFFQ29ReDRBTy9acmJ6dXEwUlpSY0tYd1hQeW81UmdPZndyRWtIWnpZSStQVGhIUmFuelczeGpXcU5vTzFJa3ZOWUV6SGpEWU5iVEJ5VDgzbzdtVlVsUWZhYUpKSm5CMVJGbFQ1SXM0NHpZQ0RJYWZKNHhmQzZTOFNKaWxjV0x1WURoc24xRjdha2xSZllnemRIMjR3WnJycS9JU0pPZjFzVHNQSHNtcE9PaWZ2S2ZyaElFemtJSEs3OFZUTFBMd0krWmNEK3VZc1FCQkt5NlEvZFBCSkZodWsyMXFiOVU1V3dZWWpPYkZSQjdzUmpZYkNsSlpyaTZzVWFXQU1WOXVsQ2JGS2NPM2xxMERPaWRuQjNqSXJ4blh4Y3JjVHl3MEkzV3JjN2k2ZG1nejlXMTFvYTR5VUpJWU92R1lkdWNXdk1pemk3b01mck5SdXE0SVJ1djR6ai9Cemcxb2NZalB5Y0RvK2I2M0RheWpyWmVNS1c4OGNRUnlvUDdpbExsMVNVVmFlRUxZQ3lieitCYUxpd2x1d0lpcWxFckJrTDNlOXptNGpJYz0iLCJjaWQiOiJNdz09Ok13PT06TjJSaFpHSTNPR010WXpVeE5DMDBPVGt6TFdJM016a3ROREUzWW1KaE1ETmtNRFU0In0.AOt6rXbcK44RD7XNCMN16zjvurzdkMNCki3HkvZ_VJ43eDkCDDbquDSvW0SmEnp9cqhjMbUqnO-iGJheI4TbkIc9dxFouJGtHvKFAjOG7LFSErwvH0yNXus1TPN41BCp_jP1tpH63s3PuRqgdzzn1axkJ57aGo9ibqnKRm7ZhM8pgkReWQpHwlFz3QuOMFWHNmPm_HMePPsUxZM7OpARwgShGMqATHEJmoIff2S1yLLeN0k97JT4BzL7xwM9VB-Yssq1rWxBp3GITcBta5R1EVjzaEZseYn_wxFFmVlXQtu_lkvbgihEsvCgtXI_c-EGZl_gTVe9DMfq4cM2XXfE8A' http://dataprovider-dataplane.tx.test/api/public  | jq
+```
+
+:::info
+Currently the response for this curl commoand is
+
+```json
+{
+  "userId": 1,
+  "id": 3,
+  "title": "fugiat veniam minus",
+  "completed": false
+}
 ```
 
 ## Notice

--- a/docs/tutorials/e2e/boost/provideData.md
+++ b/docs/tutorials/e2e/boost/provideData.md
@@ -5,25 +5,32 @@ sidebar_position: 2
 
 ## Create first data asset
 
-In this step we will focus on inserting data into our provider connector (Alice) using
+In this step we will focus on inserting data into our provider connector using
 the [Management API](https://app.swaggerhub.com/apis/eclipse-edc-bot/management-api). We will use plain
 CLI tools (`curl`) for this, but feel free to use graphical tools such as Postman or Insomnia.
+
+:::note
+
+Alice acts here as a data consumer and Bob as a data provider.
+
+- Bob -> <http://dataprovider-controlplane.tx.test>
+- Alice -> <>
+
+:::
 
 Alice, as a data consumer, wants to consume data from Bob. Bob, as a data provider, needs to create an asset for Alice.
 Action (Bob): Create this asset using the following `curl` command:
 
 ```shell
-curl --location 'http://localhost/bob/management/v2/assets' \
+curl --location 'http://dataprovider-controlplane.tx.test/management/v3/assets' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST2' \
 --data-raw '{
     "@context": {},
-    "asset": {
-        "@type": "Asset",
-        "@id": "3", 
-        "properties": {
-            "description": "Product EDC Demo Asset 3"
-        }
+    "@type": "Asset",
+    "@id": "3",
+    "properties": {
+        "description": "Product EDC Demo Asset 3"
     },
     "dataAddress": {
         "@type": "DataAddress",
@@ -33,6 +40,91 @@ curl --location 'http://localhost/bob/management/v2/assets' \
 }' | jq
 ```
 
+Just to be sure, that the asset was created succesfully, Bob can check the asset using the following `curl` command:
+
+```shell
+curl -X POST http://dataprovider-controlplane.tx.test/management/v2/assets/request -H "x-api-key: TEST2" -H "content-type: application/json" | jq
+```
+
+The result shows the already existing assets and the newly created asset.
+
+```json
+[
+  {
+    "@id": "registry-asset",
+    "@type": "edc:Asset",
+    "edc:properties": {
+      "edc:type": "data.core.digitalTwinRegistry",
+      "edc:description": "Digital Twin Registry Endpoint of IRS DEV",
+      "edc:id": "registry-asset"
+    },
+    "edc:dataAddress": {
+      "@type": "edc:DataAddress",
+      "edc:proxyPath": "true",
+      "edc:type": "HttpData",
+      "edc:proxyMethod": "true",
+      "edc:proxyQueryParams": "true",
+      "edc:proxyBody": "true",
+      "edc:baseUrl": "http://umbrella-dataprovider-dtr:8080/api/v3.0"
+    },
+    "@context": {
+      "dct": "https://purl.org/dc/terms/",
+      "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+      "edc": "https://w3id.org/edc/v0.0.1/ns/",
+      "dcat": "https://www.w3.org/ns/dcat/",
+      "odrl": "http://www.w3.org/ns/odrl/2/",
+      "dspace": "https://w3id.org/dspace/v0.8/"
+    }
+  },
+  {
+    "@id": "urn:uuid:dc641d45-95e7-4284-a472-43f30255d0cb",
+    "@type": "edc:Asset",
+    "edc:properties": {
+      "edc:description": "IRS EDC Test Asset",
+      "edc:id": "urn:uuid:dc641d45-95e7-4284-a472-43f30255d0cb"
+    },
+    "edc:dataAddress": {
+      "@type": "edc:DataAddress",
+      "edc:proxyPath": "true",
+      "edc:type": "HttpData",
+      "edc:proxyMethod": "false",
+      "edc:proxyQueryParams": "false",
+      "edc:proxyBody": "false",
+      "edc:baseUrl": "http://umbrella-dataprovider-submodelserver:8080"
+    },
+    "@context": {
+      "dct": "https://purl.org/dc/terms/",
+      "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+      "edc": "https://w3id.org/edc/v0.0.1/ns/",
+      "dcat": "https://www.w3.org/ns/dcat/",
+      "odrl": "http://www.w3.org/ns/odrl/2/",
+      "dspace": "https://w3id.org/dspace/v0.8/"
+    }
+  },
+  {
+    "@id": "3",
+    "@type": "edc:Asset",
+    "edc:properties": {
+      "edc:description": "Product EDC Demo Asset 3",
+      "edc:id": "3"
+    },
+    "edc:dataAddress": {
+      "@type": "edc:DataAddress",
+      "edc:type": "HttpData",
+      "edc:baseUrl": "https://jsonplaceholder.typicode.com/todos/3"
+    },
+    "@context": {
+      "dct": "https://purl.org/dc/terms/",
+      "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+      "edc": "https://w3id.org/edc/v0.0.1/ns/",
+      "dcat": "https://www.w3.org/ns/dcat/",
+      "odrl": "http://www.w3.org/ns/odrl/2/",
+      "dspace": "https://w3id.org/dspace/v0.8/"
+    }
+  }
+]
+```
+
 ## Request catalog
 
 Bob tells Alice, that he created an asset, and she should now be able to request it. In the next step, Alice requests a contract offer catalog. In the catalog, all contract offers for Alice are listed.
@@ -40,13 +132,13 @@ Bob tells Alice, that he created an asset, and she should now be able to request
 Action (Alice): Execute a request using the following `curl` commands:
 
 ```shell
-curl --location 'http://localhost/alice/management/v2/catalog/request' \
+curl --location 'http://dataconsumer-1-controlplane.tx.test/management/v2/catalog/request' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST1' \
 --data-raw '{
     "@context": {},
     "protocol": "dataspace-protocol-http",
-    "counterPartyAddress": "http://bob-controlplane:8084/api/v1/dsp",
+    "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
     "querySpec": {
         "offset": 0,
         "limit": 100
@@ -54,20 +146,137 @@ curl --location 'http://localhost/alice/management/v2/catalog/request' \
 }' | jq
 ```
 
+The requested catalog looks like this:
+
+```json
+{
+  "@id": "be17c3e7-3156-46db-8934-f1ea92d1f2a3",
+  "@type": "dcat:Catalog",
+  "dcat:dataset": [
+    {
+      "@id": "registry-asset",
+      "@type": "dcat:Dataset",
+      "odrl:hasPolicy": {
+        "@id": "MTcxODBlMTAtNmFjNS00NTYzLWE2MTUtNGM1MjQ5ZTUxMTU5:cmVnaXN0cnktYXNzZXQ=:NzE0ODk2YjMtY2VlYy00NmY5LWE5ZTgtY2NiMWI1NGUzOTgy",
+        "@type": "odrl:Set",
+        "odrl:permission": {
+          "odrl:target": "registry-asset",
+          "odrl:action": {
+            "odrl:type": "USE"
+          },
+          "odrl:constraint": {
+            "odrl:or": {
+              "odrl:leftOperand": "PURPOSE",
+              "odrl:operator": {
+                "@id": "odrl:eq"
+              },
+              "odrl:rightOperand": "ID 3.0 Trace"
+            }
+          }
+        },
+        "odrl:prohibition": [],
+        "odrl:obligation": [],
+        "odrl:target": "registry-asset"
+      },
+      "dcat:distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "HttpProxy"
+          },
+          "dcat:accessService": "49a693e0-835d-457a-99b4-e781f2bd643d"
+        },
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "AmazonS3"
+          },
+          "dcat:accessService": "49a693e0-835d-457a-99b4-e781f2bd643d"
+        }
+      ],
+      "edc:type": "data.core.digitalTwinRegistry",
+      "edc:description": "Digital Twin Registry Endpoint of IRS DEV",
+      "edc:id": "registry-asset"
+    },
+    {
+      "@id": "urn:uuid:dc641d45-95e7-4284-a472-43f30255d0cb",
+      "@type": "dcat:Dataset",
+      "odrl:hasPolicy": {
+        "@id": "MTIzYjJlM2QtNTUxOC00ZWViLWFmMGItNTU5ZTYxZGY3Zjhk:dXJuOnV1aWQ6ZGM2NDFkNDUtOTVlNy00Mjg0LWE0NzItNDNmMzAyNTVkMGNi:YzBhOGFhOTQtNzg4OS00Y2MxLTkzNmMtMWYwMTNkODc3Nzk4",
+        "@type": "odrl:Set",
+        "odrl:permission": {
+          "odrl:target": "urn:uuid:dc641d45-95e7-4284-a472-43f30255d0cb",
+          "odrl:action": {
+            "odrl:type": "USE"
+          },
+          "odrl:constraint": {
+            "odrl:or": {
+              "odrl:leftOperand": "PURPOSE",
+              "odrl:operator": {
+                "@id": "odrl:eq"
+              },
+              "odrl:rightOperand": "ID 3.0 Trace"
+            }
+          }
+        },
+        "odrl:prohibition": [],
+        "odrl:obligation": [],
+        "odrl:target": "urn:uuid:dc641d45-95e7-4284-a472-43f30255d0cb"
+      },
+      "dcat:distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "HttpProxy"
+          },
+          "dcat:accessService": "49a693e0-835d-457a-99b4-e781f2bd643d"
+        },
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "AmazonS3"
+          },
+          "dcat:accessService": "49a693e0-835d-457a-99b4-e781f2bd643d"
+        }
+      ],
+      "edc:description": "IRS EDC Test Asset",
+      "edc:id": "urn:uuid:dc641d45-95e7-4284-a472-43f30255d0cb"
+    }
+  ],
+  "dcat:service": {
+    "@id": "49a693e0-835d-457a-99b4-e781f2bd643d",
+    "@type": "dcat:DataService",
+    "dct:terms": "connector",
+    "dct:endpointUrl": "http://dataprovider-controlplane.tx.test/api/v1/dsp"
+  },
+  "edc:participantId": "BPNL00000003AYRE",
+  "@context": {
+    "dct": "https://purl.org/dc/terms/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dcat": "https://www.w3.org/ns/dcat/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/v0.8/"
+  }
+}
+```
+
 ## Create first access policy
 
 Let´s see if Alice can see the Asset (ID: 3).
 
+:::info
 As you can see in the response, the data offer "Product EDC Demo Asset 3" (asset ID: 3) does not appear. Unfortunately, Alice sees some contract offers but she cannot find the contract offer from Bob.
+:::
 
 Alice calls Bob and says she can´t see the asset. Bob remembers that he did not create an access policy. An access policy defines who is allowed to see a data offering.
 
 Action (Bob): Create the access policy using the following `curl` command:
 
 ```shell
-curl --location 'http://localhost/bob/management/v2/policydefinitions' \
+curl --location 'http://dataprovider-controlplane.tx.test/management/v2/policydefinitions' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST2' \
 --data-raw '{
   "@context": {
     "odrl": "http://www.w3.org/ns/odrl/2/"
@@ -80,6 +289,24 @@ curl --location 'http://localhost/bob/management/v2/policydefinitions' \
 }' | jq
 ```
 
+The polica was successfully created, if the response is something like this
+
+```json
+{
+  "@type": "edc:IdResponse",
+  "@id": "3-1",
+  "edc:createdAt": 1715627034106,
+  "@context": {
+    "dct": "https://purl.org/dc/terms/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dcat": "https://www.w3.org/ns/dcat/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/v0.8/"
+  }
+}
+```
+
 ## Request catalog - second try
 
 Now that Bob created an access policy, Alice can once again try to access Bob's asset.
@@ -87,13 +314,13 @@ Now that Bob created an access policy, Alice can once again try to access Bob's 
 Action (Alice): Execute the request again using the following `curl` command:
 
 ```shell
-curl --location 'http://localhost/alice/management/v2/catalog/request' \
+curl --location 'http://dataconsumer-1-controlplane.tx.test/management/v2/catalog/request' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST1' \
 --data-raw '{
     "@context": {},
     "protocol": "dataspace-protocol-http",
-    "counterPartyAddress": "http://bob-controlplane:8084/api/v1/dsp",
+    "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
     "querySpec": {
         "offset": 0,
         "limit": 100
@@ -125,9 +352,9 @@ Since an access policy has already been created, a contract policy must be creat
 Action (BoB): Create the contract policy using the following `curl` command:
 
 ```shell
-curl --location 'http://localhost/bob/management/v2/policydefinitions' \
+curl --location 'http://dataprovider-controlplane.tx.test/management/v2/policydefinitions' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST2' \
 --data-raw '{
   "@context": {
     "odrl": "http://www.w3.org/ns/odrl/2/"
@@ -140,12 +367,30 @@ curl --location 'http://localhost/bob/management/v2/policydefinitions' \
 }' | jq
 ```
 
+And again the policy was successfully created
+
+```json
+{
+  "@type": "edc:IdResponse",
+  "@id": "3-2",
+  "edc:createdAt": 1715627218849,
+  "@context": {
+    "dct": "https://purl.org/dc/terms/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dcat": "https://www.w3.org/ns/dcat/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/v0.8/"
+  }
+}
+```
+
 Action (Bob): Create a contract definition including the asset and the policies you have created. For this, use the following `curl` command:
 
 ```shell
-curl --location 'http://localhost/bob/management/v2/contractdefinitions' \
+curl --location 'http://dataprovider-controlplane.tx.test/management/v2/contractdefinitions' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST2' \
 --data-raw '{
   "@context": {},
   "@id": "3",
@@ -159,6 +404,24 @@ curl --location 'http://localhost/bob/management/v2/contractdefinitions' \
     "operandRight": "3"
   }
 }' | jq
+```
+
+As a check, the result should look like this:
+
+```json
+{
+  "@type": "edc:IdResponse",
+  "@id": "3",
+  "edc:createdAt": 1715627302307,
+  "@context": {
+    "dct": "https://purl.org/dc/terms/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dcat": "https://www.w3.org/ns/dcat/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/v0.8/"
+  }
+}
 ```
 
 ## Request catalog - third try
@@ -181,11 +444,43 @@ curl --location 'http://localhost/alice/management/v2/catalog/request' \
 }' | jq
 ```
 
+In the response an additional entry should appear:
+
+```json
+{
+      "@id": "3",
+      "@type": "dcat:Dataset",
+      "odrl:hasPolicy": {
+        "@id": "Mw==:Mw==:ZDA5YzE2ZWYtMzkyZC00ODExLWE5NjEtN2U4ZjRhMTU3ZGRh",
+        "@type": "odrl:Set",
+        "odrl:permission": [],
+        "odrl:prohibition": [],
+        "odrl:obligation": [],
+        "odrl:target": "3"
+      },
+      "dcat:distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "HttpProxy"
+          },
+          "dcat:accessService": "49a693e0-835d-457a-99b4-e781f2bd643d"
+        },
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "AmazonS3"
+          },
+          "dcat:accessService": "49a693e0-835d-457a-99b4-e781f2bd643d"
+        }
+      ],
+      "edc:description": "Product EDC Demo Asset 3",
+      "edc:id": "3"
+    }
+```
+
 :::info
-
-Finally Alice can see the Contract Offer from Bob.
-Congratulations on yor first successful offering of data in your own data space!
-
+Finally Alice can see the Contract Offer from Bob. Congratulations on yor first successful offering of data in your own data space!
 :::
 
 ## Notice

--- a/docs/tutorials/e2e/boost/provideData.md
+++ b/docs/tutorials/e2e/boost/provideData.md
@@ -430,13 +430,13 @@ Let´s see if Alice can finally see the Asset.
 Action (Alice): Execute the request again using the following `curl` command:
 
 ```shell
-curl --location 'http://localhost/alice/management/v2/catalog/request' \
+curl --location 'http://dataconsumer-1-controlplane.tx.test/management/v2/catalog/request' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST1' \
 --data-raw '{
     "@context": {},
     "protocol": "dataspace-protocol-http",
-    "counterPartyAddress": "http://bob-controlplane:8084/api/v1/dsp",
+    "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
     "querySpec": {
         "offset": 0,
         "limit": 100

--- a/docs/tutorials/e2e/boost/restrictData.md
+++ b/docs/tutorials/e2e/boost/restrictData.md
@@ -11,42 +11,34 @@ The first step for Bob will again be to create an asset.
 Action (Bob): Create an asset using the following `curl` command:
 
 ```shell
-curl --location 'http://localhost/bob/management/v2/assets' \
+curl --location 'http://dataprovider-controlplane.tx.test/management/v3/assets' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST2' \
 --data-raw '{
     "@context": {},
-    "asset": {
-        "@type": "Asset",
-        "@id": "4", 
-        "properties": {
-            "description": "Product EDC Demo Asset 4"
-        }
+    "@type": "Asset",
+    "@id": "4",
+    "properties": {
+        "description": "Product EDC Demo Asset 4"
     },
     "dataAddress": {
         "@type": "DataAddress",
         "type": "HttpData",
         "baseUrl": "https://jsonplaceholder.typicode.com/todos/4"
     }
-}'
+}' | jq
 ```
 
 ## Create a permissive access policy
 
-Now that the asset has been created, Bob creates an access policy that defines who can see and therefore access the asset in his catalog. To specify this access, Bob uses the Business Partner Number (BPN). The BPN is a unique identifier for participants of a data space. Bob knows that his exchange partner for this asset has the BPN (BPNL000000000003). Therefore, he can define his access policy as follows:
-
-:::info
-
-The MXD contains only two members (Alice & Bob). Therefore, it will not be possible to consume an asset with the policy defined here, because the participant with the BPN BPNL000000000003 does not exist in this data space. This is an example to demonstrate the restriction of an asset with a policy.
-
-:::
+Now that the asset has been created, Bob creates an access policy that defines who can see and therefore access the asset in his catalog. To specify this access, Bob uses the Business Partner Number (BPN). The BPN is a unique identifier for participants of a data space. Bob knows that his exchange partner for this asset has the BPN `BPNL00000003AVTH` and Alice BPN is `BPNL00000003AZQP`
 
 Action (Bob): Create the access policy using the following `curl` command:
 
 ```shell
-curl --location 'http://localhost/bob/management/v2/policydefinitions' \
+curl --location 'http://dataprovider-controlplane.tx.test/management/v2/policydefinitions' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST2' \
 --data-raw '{
   "@context": {
     "odrl": "http://www.w3.org/ns/odrl/2/"
@@ -67,17 +59,35 @@ curl --location 'http://localhost/bob/management/v2/policydefinitions' \
               "odrl:operator": {
                 "@id": "odrl:eq"
               },
-              "odrl:rightOperand": "BPNL000000000003"
+              "odrl:rightOperand": "BPNL00000003AVTH"
             }
           ]
         }
       }
     ]
   }
-}' 
+}' | jq
 ```
 
-Bob defined a policy which restricts access to connector(s) with the BusinessPartnerNumber BPNL000000000003. As Alice does not own this BPN, she should not be able to access the asset.
+The policydefinitioon is created with the ID `41`
+
+```json
+{
+  "@type": "edc:IdResponse",
+  "@id": "41",
+  "edc:createdAt": 1715674423858,
+  "@context": {
+    "dct": "https://purl.org/dc/terms/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dcat": "https://www.w3.org/ns/dcat/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/v0.8/"
+  }
+}
+```
+
+Bob defined a policy which restricts access to connector(s) with the BusinessPartnerNumber `BPNL00000003AVTH`. As Alice does not own this BPN, she should not be able to access the asset.
 
 ## Create a permissive contract policy
 
@@ -86,9 +96,9 @@ Since an access policy has already been created, a contract policy must be creat
 Action (Bob): Create the contract policy using the following `curl` command:
 
 ```shell
-curl --location 'http://localhost/bob/management/v2/policydefinitions' \
+curl --location 'http://dataprovider-controlplane.tx.test/management/v2/policydefinitions' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST2' \
 --data-raw '{
   "@context": {
     "odrl": "http://www.w3.org/ns/odrl/2/"
@@ -116,7 +126,25 @@ curl --location 'http://localhost/bob/management/v2/policydefinitions' \
       }
     ]
   }
-}'
+}' | jq
+```
+
+The response should be something like this
+
+```json
+{
+  "@type": "edc:IdResponse",
+  "@id": "42",
+  "edc:createdAt": 1715674546763,
+  "@context": {
+    "dct": "https://purl.org/dc/terms/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dcat": "https://www.w3.org/ns/dcat/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/v0.8/"
+  }
+}
 ```
 
 ## Create a contract definition
@@ -125,9 +153,9 @@ Lastly, the asset and the access policy must be linked in a contract definition.
 Action (Bob): Create a contract definition including the asset and the policies you have created. For this, use the following `curl` command:
 
 ```shell
-curl --location 'http://localhost/bob/management/v2/contractdefinitions' \
+curl --location 'http://dataprovider-controlplane.tx.test/management/v2/contractdefinitions' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST2' \
 --data-raw '{
     "@context": {},
     "@id": "4",
@@ -140,7 +168,25 @@ curl --location 'http://localhost/bob/management/v2/contractdefinitions' \
         "operator": "=",
         "operandRight": "4"
     }
-}'
+}' | jq
+```
+
+A response should look like this
+
+```json
+{
+  "@type": "edc:IdResponse",
+  "@id": "4",
+  "edc:createdAt": 1715674670136,
+  "@context": {
+    "dct": "https://purl.org/dc/terms/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dcat": "https://www.w3.org/ns/dcat/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/v0.8/"
+  }
+}
 ```
 
 ## Request catalog
@@ -150,23 +196,168 @@ Let´s see if Alice can see the Asset.
 Action (Alice): Execute a request using the following `curl` command:
 
 ```shell
-curl --location 'http://localhost/alice/management/v2/catalog/request' \
+curl --location 'http://dataconsumer-1-controlplane.tx.test/management/v2/catalog/request' \
 --header 'Content-Type: application/json' \
---header 'X-Api-Key: password' \
+--header 'X-Api-Key: TEST1' \
 --data-raw '{
     "@context": {},
     "protocol": "dataspace-protocol-http",
-    "counterPartyAddress": "http://bob-controlplane:8084/api/v1/dsp",
+    "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
     "querySpec": {
         "offset": 0,
         "limit": 100
     }
-}'
+}' | jq
+```
+
+The response doesnt include the cataolog entry for the asset/offer with id4
+
+```json
+{
+  "@id": "3b276870-5cc5-4546-b793-e2c8d39e1010",
+  "@type": "dcat:Catalog",
+  "dcat:dataset": [
+    {
+      "@id": "registry-asset",
+      "@type": "dcat:Dataset",
+      "odrl:hasPolicy": {
+        "@id": "ZGM3MjMyYTAtMDRjOC00MTVjLWI2NmQtOGJmNTQ1MWMyYmIy:cmVnaXN0cnktYXNzZXQ=:MjdiYWExMGItMTAzMC00MmY5LWI0YjMtMzJmY2UyODI5NThl",
+        "@type": "odrl:Set",
+        "odrl:permission": {
+          "odrl:target": "registry-asset",
+          "odrl:action": {
+            "odrl:type": "USE"
+          },
+          "odrl:constraint": {
+            "odrl:or": {
+              "odrl:leftOperand": "PURPOSE",
+              "odrl:operator": {
+                "@id": "odrl:eq"
+              },
+              "odrl:rightOperand": "ID 3.0 Trace"
+            }
+          }
+        },
+        "odrl:prohibition": [],
+        "odrl:obligation": [],
+        "odrl:target": "registry-asset"
+      },
+      "dcat:distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "HttpProxy"
+          },
+          "dcat:accessService": "7b76c9c5-d7f9-42c1-8784-a2820a60bb0f"
+        },
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "AmazonS3"
+          },
+          "dcat:accessService": "7b76c9c5-d7f9-42c1-8784-a2820a60bb0f"
+        }
+      ],
+      "edc:type": "data.core.digitalTwinRegistry",
+      "edc:description": "Digital Twin Registry Endpoint of IRS DEV",
+      "edc:id": "registry-asset"
+    },
+    {
+      "@id": "urn:uuid:69653fc9-11b5-4321-98ca-e60d2dc35379",
+      "@type": "dcat:Dataset",
+      "odrl:hasPolicy": {
+        "@id": "MDkyNmVhMGUtZWVmMC00OTlmLTliZjktNmE1MGU3MGUzOGQy:dXJuOnV1aWQ6Njk2NTNmYzktMTFiNS00MzIxLTk4Y2EtZTYwZDJkYzM1Mzc5:YWUwOTFiOTYtNGM0Ni00YzE0LWEyZGYtY2Y5NDNlMzY1NDY4",
+        "@type": "odrl:Set",
+        "odrl:permission": {
+          "odrl:target": "urn:uuid:69653fc9-11b5-4321-98ca-e60d2dc35379",
+          "odrl:action": {
+            "odrl:type": "USE"
+          },
+          "odrl:constraint": {
+            "odrl:or": {
+              "odrl:leftOperand": "PURPOSE",
+              "odrl:operator": {
+                "@id": "odrl:eq"
+              },
+              "odrl:rightOperand": "ID 3.0 Trace"
+            }
+          }
+        },
+        "odrl:prohibition": [],
+        "odrl:obligation": [],
+        "odrl:target": "urn:uuid:69653fc9-11b5-4321-98ca-e60d2dc35379"
+      },
+      "dcat:distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "HttpProxy"
+          },
+          "dcat:accessService": "7b76c9c5-d7f9-42c1-8784-a2820a60bb0f"
+        },
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "AmazonS3"
+          },
+          "dcat:accessService": "7b76c9c5-d7f9-42c1-8784-a2820a60bb0f"
+        }
+      ],
+      "edc:description": "IRS EDC Test Asset",
+      "edc:id": "urn:uuid:69653fc9-11b5-4321-98ca-e60d2dc35379"
+    },
+    {
+      "@id": "3",
+      "@type": "dcat:Dataset",
+      "odrl:hasPolicy": {
+        "@id": "Mw==:Mw==:YjE0ODU2M2MtMWM5MC00NDg4LThmZmItZmJjZjc0NjQzZTE5",
+        "@type": "odrl:Set",
+        "odrl:permission": [],
+        "odrl:prohibition": [],
+        "odrl:obligation": [],
+        "odrl:target": "3"
+      },
+      "dcat:distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "HttpProxy"
+          },
+          "dcat:accessService": "7b76c9c5-d7f9-42c1-8784-a2820a60bb0f"
+        },
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "AmazonS3"
+          },
+          "dcat:accessService": "7b76c9c5-d7f9-42c1-8784-a2820a60bb0f"
+        }
+      ],
+      "edc:description": "Product EDC Demo Asset 3",
+      "edc:id": "3"
+    }
+  ],
+  "dcat:service": {
+    "@id": "7b76c9c5-d7f9-42c1-8784-a2820a60bb0f",
+    "@type": "dcat:DataService",
+    "dct:terms": "connector",
+    "dct:endpointUrl": "http://dataprovider-controlplane.tx.test/api/v1/dsp"
+  },
+  "edc:participantId": "BPNL00000003AYRE",
+  "@context": {
+    "dct": "https://purl.org/dc/terms/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dcat": "https://www.w3.org/ns/dcat/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/v0.8/"
+  }
+}
 ```
 
 :::info
 
-Bob’s asset (ID: 4) should not be displayed. The access policy successfully restricts Alice from seeing and therefore obtaining Bob’s asset. Now Bob is able to manage who sees which of his sensitive data assets. If Bob decides to enable Alice to see his asset, he can simply adjust the access policy definition and add Alice BPN (BPNL000000000001) to the list of BPNs.
+Bob’s asset (ID: 4) should not be displayed. The access policy successfully restricts Alice from seeing and therefore obtaining Bob’s asset. Now Bob is able to manage who sees which of his sensitive data assets. If Bob decides to enable Alice to see his asset, he can simply adjust the access policy definition and add Alice BPN `BPNL00000003AZQP` to the list of BPNs.
 
 :::
 


### PR DESCRIPTION
## Description

This PR adapts the boost section in the tutorial. With the new umbrella helm chart a new set (infastructure was created) is used. Therefore, the curl commands are exchanged, or adapted. For better understanding, this PR also add a check curl command to see if the creation process was successful.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
